### PR TITLE
解决容器失联问题

### DIFF
--- a/master/master.go
+++ b/master/master.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"sync"
 	"syscall"
 
 	"github.com/baetyl/baetyl/logger"
@@ -26,6 +27,7 @@ type Master struct {
 	infostats *infoStats
 	sig       chan os.Signal
 	log       logger.Logger
+	sync.RWMutex
 }
 
 // New creates a new master

--- a/master/service.go
+++ b/master/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/baetyl/baetyl/master/engine"
-	"github.com/baetyl/baetyl/sdk/baetyl-go"
+	baetyl "github.com/baetyl/baetyl/sdk/baetyl-go"
 	"github.com/docker/distribution/uuid"
 )
 

--- a/master/service.go
+++ b/master/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/baetyl/baetyl/master/engine"
-	"github.com/baetyl/baetyl/sdk/baetyl-go"
+	baetyl "github.com/baetyl/baetyl/sdk/baetyl-go"
 	"github.com/docker/distribution/uuid"
 )
 
@@ -48,6 +48,8 @@ func (m *Master) startServices(cur baetyl.ComposeAppConfig) error {
 }
 
 func (m *Master) stopServices(keepServices map[string]struct{}) {
+	m.Lock()
+	defer m.Unlock()
 	var wg sync.WaitGroup
 	for item := range m.services.IterBuffered() {
 		s := item.Val.(engine.Service)
@@ -84,6 +86,8 @@ func (m *Master) ReportInstance(serviceName, instanceName string, partialStats e
 
 // StartInstance starts a service instance
 func (m *Master) StartInstance(service, instance string, dynamicConfig map[string]string) error {
+	m.RLock()
+	defer m.RUnlock()
 	s, ok := m.services.Get(service)
 	if !ok {
 		return fmt.Errorf("service (%s) not found", service)

--- a/master/service.go
+++ b/master/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/baetyl/baetyl/master/engine"
-	baetyl "github.com/baetyl/baetyl/sdk/baetyl-go"
+	"github.com/baetyl/baetyl/sdk/baetyl-go"
 	"github.com/docker/distribution/uuid"
 )
 

--- a/master/service.go
+++ b/master/service.go
@@ -64,8 +64,8 @@ func (m *Master) stopServices(keepServices map[string]struct{}) {
 		wg.Add(1)
 		go func(s engine.Service) {
 			defer wg.Done()
-			m.services.Remove(s.Name())
 			s.Stop()
+			m.services.Remove(s.Name())
 			m.accounts.Remove(s.Name())
 			m.engine.DelServiceStats(s.Name(), true)
 			m.log.Infof("service (%s) stopped", s.Name())
@@ -92,21 +92,7 @@ func (m *Master) StartInstance(service, instance string, dynamicConfig map[strin
 	if !ok {
 		return fmt.Errorf("service (%s) not found", service)
 	}
-	err := s.(engine.Service).StartInstance(instance, dynamicConfig)
-	if err != nil {
-		return err
-	}
-	_, okAgain := m.services.Get(service)
-	if !okAgain {
-		m.log.Errorf("service (%s) do not exist,stop instance (%s)", service, instance)
-		return StopInstance(s, instance)
-	}
-	return nil
-}
-
-// StopInstance stops a service instance
-func StopInstance(s interface{}, instance string) error {
-	return s.(engine.Service).StopInstance(instance)
+	return s.(engine.Service).StartInstance(instance, dynamicConfig)
 }
 
 // StopInstance stops a service instance


### PR DESCRIPTION
在很多容器正在启动的时候，下发新的版本，会造成容器脱离baetyl控制的问题，
修改了两个方法 ：
其中stopServices确实有问题，
StartInstance怀疑会有问题