### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -51,8 +51,7 @@ func TestNewChain(t *testing.T) {
 	cfg, ctl, data := initChainEnv(t)
 	ami := mock.NewMockAMI(ctl)
 
-	err := os.Setenv(context.KeyRunMode, context.RunModeNative)
-	assert.NoError(t, err)
+	t.Setenv(context.KeyRunMode, context.RunModeNative)
 	c, err := NewChain(cfg, ami, data)
 	assert.Error(t, err, ErrParseData)
 	data["port"] = "22"
@@ -76,8 +75,6 @@ func TestNewChain(t *testing.T) {
 	cfg.Plugin.Pubsub = "not exist"
 	_, err = NewChain(cfg, ami, data)
 	assert.Error(t, err)
-	err = os.Unsetenv(context.KeyRunMode)
-	assert.NoError(t, err)
 }
 
 func TestChainMsg(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -116,7 +116,7 @@ func TestCollect(t *testing.T) {
 	ns := context.EdgeNamespace()
 	apps := []specv1.AppInfo{info}
 	appStats := []specv1.AppStats{{AppInfo: info}}
-	os.Setenv(kube.KubeNodeName, "knn")
+	t.Setenv(kube.KubeNodeName, "knn")
 	mockAmi.EXPECT().CollectNodeInfo().Return(nodeInfo, nil)
 	mockAmi.EXPECT().CollectNodeStats().Return(nodeStats, nil)
 	mockAmi.EXPECT().StatsApps(gomock.Any()).Return(appStats, nil)
@@ -264,7 +264,7 @@ func TestReportAndApply(t *testing.T) {
 	infos := map[string]interface{}{}
 	stats := map[string]interface{}{}
 
-	os.Setenv(kube.KubeNodeName, "knn")
+	t.Setenv(kube.KubeNodeName, "knn")
 	mockAmi.EXPECT().CollectNodeInfo().Return(infos, nil)
 	mockAmi.EXPECT().CollectNodeStats().Return(stats, nil)
 	appStats := []specv1.AppStats{{AppInfo: specv1.AppInfo{Name: "app1", Version: "v1"}}, {AppInfo: specv1.AppInfo{Name: "app2", Version: "v2"}}}

--- a/engine/msg_handler_test.go
+++ b/engine/msg_handler_test.go
@@ -29,8 +29,7 @@ var (
 )
 
 func genHandlerDownsideEngine(t *testing.T) (*engineImpl, *mock.MockAMI, *gomock.Controller) {
-	err := os.Setenv(context.KeySvcName, specV1.BaetylCore)
-	assert.NoError(t, err)
+	t.Setenv(context.KeySvcName, specV1.BaetylCore)
 	// prepare struct
 	cfg := config.Config{}
 

--- a/initz/activate_collector_test.go
+++ b/initz/activate_collector_test.go
@@ -2,7 +2,6 @@ package initz
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -89,7 +88,7 @@ func TestActivate_Err_Collector(t *testing.T) {
 	assert.Error(t, err)
 
 	ami := mc.NewMockAMI(mockCtl)
-	os.Setenv(kube.KubeNodeName, "knn")
+	t.Setenv(kube.KubeNodeName, "knn")
 	ami.EXPECT().CollectNodeInfo().Return(map[string]interface{}{"knn": nil}, nil).AnyTimes()
 	active = genActivate(t, c, ami)
 

--- a/initz/activate_test.go
+++ b/initz/activate_test.go
@@ -194,7 +194,7 @@ func TestActivate(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
 	ami := mc.NewMockAMI(mockCtl)
-	os.Setenv(kube.KubeNodeName, "knn")
+	t.Setenv(kube.KubeNodeName, "knn")
 	ami.EXPECT().CollectNodeInfo().Return(map[string]interface{}{"knn": nodeInfo}, nil).Times(len(goodCases))
 
 	err = os.MkdirAll(defaultSNPath, 0755)
@@ -257,7 +257,7 @@ func TestActivate_Err_Response(t *testing.T) {
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
 	ami := mc.NewMockAMI(mockCtl)
-	os.Setenv(kube.KubeNodeName, "knn")
+	t.Setenv(kube.KubeNodeName, "knn")
 	ami.EXPECT().CollectNodeInfo().Return(map[string]interface{}{"knn": nodeInfo}, nil).AnyTimes()
 
 	active := genActivate(t, c, ami)

--- a/sync/app_test.go
+++ b/sync/app_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"os"
 	"testing"
 
 	"github.com/baetyl/baetyl-go/v2/context"
@@ -10,8 +9,7 @@ import (
 )
 
 func TestSync_PrepareApp(t *testing.T) {
-	err := os.Setenv(context.KeyNodeName, "node01")
-	assert.NoError(t, err)
+	t.Setenv(context.KeyNodeName, "node01")
 
 	app := specv1.Application{
 		Name:    "app1",
@@ -142,7 +140,7 @@ func TestSync_PrepareApp(t *testing.T) {
 		},
 	}
 
-	err = PrepareApp("var/lib/baetyl/host", "var/lib/baetyl/object", &app, configs)
+	err := PrepareApp("var/lib/baetyl/host", "var/lib/baetyl/object", &app, configs)
 	assert.NoError(t, err)
 	assert.EqualValues(t, expApp, app)
 }

--- a/sync/object_test.go
+++ b/sync/object_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"path/filepath"
 	gosync "sync"
 	"testing"
@@ -33,7 +32,7 @@ func TestObject_FilteringConfig(t *testing.T) {
 	}
 	FilterConfig(cfg)
 	assert.Len(t, cfg.Data, 3)
-	os.Setenv(context.KeyRunMode, context.RunModeNative)
+	t.Setenv(context.KeyRunMode, context.RunModeNative)
 	FilterConfig(cfg)
 	assert.Len(t, cfg.Data, 3)
 	cfg.Labels = map[string]string{"baetyl-config-type": "baetyl-program"}
@@ -41,7 +40,7 @@ func TestObject_FilteringConfig(t *testing.T) {
 	assert.Len(t, cfg.Data, 2)
 	assert.Equal(t, "cdascd", cfg.Data["abc"])
 	assert.Equal(t, "scdasv", cfg.Data["_object_"+context.PlatformString()])
-	os.Setenv(context.KeyRunMode, context.RunModeKube)
+	t.Setenv(context.KeyRunMode, context.RunModeKube)
 	FilterConfig(cfg)
 	assert.Len(t, cfg.Data, 1)
 	assert.Equal(t, "cdascd", cfg.Data["abc"])


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv