### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/engine/clean_test.go
+++ b/engine/clean_test.go
@@ -23,9 +23,7 @@ func TestRecycle(t *testing.T) {
 	assert.NotNil(t, f)
 	fmt.Println("-->tempfile", f.Name())
 
-	dir, err := os.MkdirTemp("", t.Name())
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
+	dir := t.TempDir()
 	fmt.Println("-->tempdir", dir)
 
 	sto, err := store.NewBoltHold(f.Name())
@@ -378,8 +376,7 @@ func TestGetDelObjectCfgs(t *testing.T) {
 }
 
 func TestCleanObjectStorage(t *testing.T) {
-	objDir, err := os.MkdirTemp("", t.Name())
-	assert.NoError(t, err)
+	objDir := t.TempDir()
 	nod, engCfg, sto := prepare(t)
 	node1 := &specv1.Node{
 		Name:    "node1",
@@ -409,7 +406,7 @@ func TestCleanObjectStorage(t *testing.T) {
 		Version: "v2",
 	}}
 	node1.Report.SetAppInfos(false, appinfo)
-	_, err = nod.Report(node1.Report, false)
+	_, err := nod.Report(node1.Report, false)
 	assert.NoError(t, err)
 	objCfg1 := specv1.Configuration{
 		Name:    "cfg1",

--- a/initz/activate_server_test.go
+++ b/initz/activate_server_test.go
@@ -90,10 +90,9 @@ var (
 )
 
 func initTemplate(t *testing.T) string {
-	tmpDir, err := os.MkdirTemp("", "pages")
-	assert.Nil(t, err)
+	tmpDir := t.TempDir()
 	activePath := path.Join(tmpDir, "active.html.template")
-	err = os.WriteFile(activePath, []byte(templateActive), 0755)
+	err := os.WriteFile(activePath, []byte(templateActive), 0755)
 	assert.Nil(t, err)
 	failedPath := path.Join(tmpDir, "filed.html.template")
 	err = os.WriteFile(failedPath, []byte(templateFailed), 0755)
@@ -104,8 +103,7 @@ func initTemplate(t *testing.T) string {
 }
 
 func TestActivate_Server(t *testing.T) {
-	tmpDir := initTemplate(t)
-	defer os.RemoveAll(tmpDir)
+	initTemplate(t)
 	c := &config.Config{}
 	c.Init.Active.Collector.Server.Listen = "www.baidu.com"
 	c.Init.Active.Collector.Attributes = []config.Attribute{

--- a/initz/initialize_test.go
+++ b/initz/initialize_test.go
@@ -63,12 +63,10 @@ auEzbTMl3QfCCeqIcloGgq72YIDedNc1MQ==
 func TestNewInitialize(t *testing.T) {
 	cfg := config.Config{}
 	// with cert
-	tmpDir, err := os.MkdirTemp("", "init")
-	assert.Nil(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	certPath := path.Join(tmpDir, "cert.pem")
-	err = os.WriteFile(certPath, []byte("cert"), 0755)
+	err := os.WriteFile(certPath, []byte("cert"), 0755)
 	assert.Nil(t, err)
 	cfg.Node.Cert = certPath
 

--- a/sync/desire_test.go
+++ b/sync/desire_test.go
@@ -111,9 +111,7 @@ func TestSyncProcessConfiguration(t *testing.T) {
 	cfg.Name = "cfg"
 
 	// object process
-	dir, err := os.MkdirTemp("", t.Name())
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
+	dir := t.TempDir()
 	syn.cfg.Sync.Download.Path = dir
 	file1 := filepath.Join(dir, "file1")
 	os.WriteFile(file1, content, 0644)

--- a/sync/object_test.go
+++ b/sync/object_test.go
@@ -61,9 +61,7 @@ func TestObject_DownloadObject(t *testing.T) {
 	assert.NotNil(t, nod)
 
 	content := []byte("test")
-	dir, err := os.MkdirTemp("", t.Name())
-	assert.NoError(t, err)
-	assert.NotNil(t, dir)
+	dir := t.TempDir()
 	fmt.Println("-->tempdir", dir)
 	file1 := filepath.Join(dir, "file1")
 	os.WriteFile(file1, content, 0644)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```